### PR TITLE
Handle nil value in GetbyteForSSLSocket::getbyte

### DIFF
--- a/lib/net/ldap/connection.rb
+++ b/lib/net/ldap/connection.rb
@@ -74,7 +74,8 @@ class Net::LDAP::Connection #:nodoc:
 
   module GetbyteForSSLSocket
     def getbyte
-      getc.ord
+      c = getc
+      c && c.ord
     end
   end
 


### PR DESCRIPTION
Related to  ruby-ldap/ruby-net-ldap#266